### PR TITLE
Fix code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @michaelmoore-s1
-* @samuelmatos-s1
-* @tjkuson-s1
+* @michaelmoore-s1 @samuelmatos-s1 @tjkuson-s1


### PR DESCRIPTION
Currently, only @tjkuson-s1 is tagged as a code owner. This is because the last matching pattern takes precedence (the line at the end).

Instead, move all code owners to the same line.